### PR TITLE
Fix print page break by making column full height

### DIFF
--- a/src/__tests__/__snapshots__/App.snapshot.spec.js.snap
+++ b/src/__tests__/__snapshots__/App.snapshot.spec.js.snap
@@ -583,7 +583,7 @@ exports[`should render the entire app 1`] = `
    
   <div>
     <div
-      class="row"
+      class="row print-flex"
     >
       <div
         class="span3 nbsp"
@@ -592,7 +592,7 @@ exports[`should render the entire app 1`] = `
       </div>
        
       <div
-        class="span9"
+        class="span9 print-flex"
       >
         <div
           class="span3 skill"
@@ -663,7 +663,7 @@ exports[`should render the entire app 1`] = `
     </div>
      
     <div
-      class="row"
+      class="row print-flex"
     >
       <div
         class="span3 nbsp"
@@ -672,7 +672,7 @@ exports[`should render the entire app 1`] = `
       </div>
        
       <div
-        class="span9"
+        class="span9 print-flex"
       >
         <div
           class="span3 skill"
@@ -743,7 +743,7 @@ exports[`should render the entire app 1`] = `
     </div>
      
     <div
-      class="row"
+      class="row print-flex"
     >
       <div
         class="span3 nbsp"
@@ -752,7 +752,7 @@ exports[`should render the entire app 1`] = `
       </div>
        
       <div
-        class="span9"
+        class="span9 print-flex"
       >
         <div
           class="span3 skill"
@@ -843,7 +843,7 @@ exports[`should render the entire app 1`] = `
    
   <div>
     <div
-      class="row"
+      class="row print-flex"
     >
       <div
         class="span3 nbsp"
@@ -852,7 +852,7 @@ exports[`should render the entire app 1`] = `
       </div>
        
       <div
-        class="span9"
+        class="span9 print-flex"
       >
         <ul
           class="disc"

--- a/src/components/SkillsRow.vue
+++ b/src/components/SkillsRow.vue
@@ -1,7 +1,7 @@
 <template>
-    <div class="row">
+    <div class="row print-flex">
         <div class="span3 nbsp">&nbsp;</div>
-        <div class="span9">
+        <div class="span9 print-flex">
             <slot></slot>
         </div>
     </div>
@@ -23,5 +23,12 @@
     /* https://github.com/vuejs/vue-cli/issues/5639 */
     .nbsp:before {
         content: "\a0";
+    }
+
+
+    @media print {
+      .print-flex {
+        display: flex;
+      }
     }
 </style>


### PR DESCRIPTION
Need to get it under 3 pages, but noticed that the page break broke the indentation as if the left column didn't exist.

![CleanShot 2023-12-04 at 17 24 30](https://github.com/mikedidomizio/mikedidomizio.com/assets/5728044/8d8417a9-af96-4fc4-a182-4a72af53ccc7)

By making it flex when printing (otherwise the skills break) we can get past this by using flex and filling the entire column height.

![CleanShot 2023-12-04 at 17 23 50](https://github.com/mikedidomizio/mikedidomizio.com/assets/5728044/ab96a3b3-b4c4-4c81-8cca-d831a296efe2)
