### PR TITLE
Change output for CSS/JS files

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,19 @@
+/**
+ * @type {import('@vue/cli-service').ProjectOptions}
+ */
+module.exports = {
+    chainWebpack: (config) => {
+        if (process.env.NODE_ENV === 'production') {
+            config
+                .plugin('extract-css')
+                .tap((args) => {
+                    args[0].filename = 'resume-css.[name].[contenthash:8].css';
+                    args[0].chunkFilename = 'resume-css.[name].[contenthash:8].css';
+                    return args;
+                })
+                .end()
+        }
+    },
+    // for js files
+    assetsDir: 'resume-js',
+}


### PR DESCRIPTION
Changes the output directory for JS files and prefixes the CSS file.

The purpose of this is for the Vercel configuration to know what files to properly rewrite